### PR TITLE
docs: revise Arch Linux Dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone this repository or download the ZIP archive and extract it.
 
 #### Arch Linux
 ```sh
-sudo pacman -Syu --needed jre-openjdk zip unzip android-sdk-build-tools
+sudo pacman -Syu yay --needed && yay -Syu jre-openjdk zip unzip android-sdk-build-tools --needed
 ```
 
 #### RHEL / Fedora / CentOS / Alma / Rocky


### PR DESCRIPTION
error: target not found: android-sdk-build-tools
pacman does not have android-sdk-build-tools, so use yay instead to fetch from AUR.